### PR TITLE
Add test cases to improve coverage of IterImpl::readStringSlowPath()

### DIFF
--- a/src/test/java/com/jsoniter/TestIterImpl.java
+++ b/src/test/java/com/jsoniter/TestIterImpl.java
@@ -49,7 +49,7 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 1);
         }
 
-	/**Test case that cover the switch case for escape code \u with a high surrogate
+	/**Test case that cover the switch case for escape code u with a high surrogate
 	followed by a low surrogate
         We read only two characters so j is only incremented by 2 and we assert that
         */
@@ -61,7 +61,7 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 2);
         }
 
-	/**Test case that cover the switch case for escape code \u with a high surrogate
+	/**Test case that cover the switch case for escape code u with a high surrogate
         followed by a random unicode (which is neither low or high surrogate)
         This should result in a JsonException and we assert that the message is the good one
         */

--- a/src/test/java/com/jsoniter/TestIterImpl.java
+++ b/src/test/java/com/jsoniter/TestIterImpl.java
@@ -56,5 +56,43 @@ public class TestIterImpl extends TestCase {
                 assertEquals(e.getMessage(), "invalid surrogate");
 	    }
         }
+
+	public void testSplitSurrogate_reusablefull() throws Exception{
+	    byte b1 = (byte) -16;
+	    byte b2 = (byte) -18;
+	    byte b3 = (byte) -18;
+	    byte b4 = (byte) -18;
+	    String str = "\"";
+	    byte[] b5 = str.getBytes();
+	    byte[] text = new byte[5];
+	    text[0] = b1;
+	    text[1] = b2;
+	    text[2] = b3;
+	    text[3] = b4;
+	    text[4] = b5[0];
+            JsonIterator iter = JsonIterator.parse(text);
+            int j = 32;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 34);
+        }
+
+	public void testSplitSurrogate_reusableOneplaceleft() throws Exception{
+            byte b1 = (byte) -16;
+            byte b2 = (byte) -18;
+            byte b3 = (byte) -18;
+            byte b4 = (byte) -18;
+            String str = "\"";
+            byte[] b5 = str.getBytes();
+            byte[] text = new byte[5];
+            text[0] = b1;
+            text[1] = b2;
+            text[2] = b3;
+            text[3] = b4;
+            text[4] = b5[0];
+            JsonIterator iter = JsonIterator.parse(text);
+            int j = 31;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 33);
+        }
 }
 

--- a/src/test/java/com/jsoniter/TestIterImpl.java
+++ b/src/test/java/com/jsoniter/TestIterImpl.java
@@ -5,6 +5,9 @@ import com.jsoniter.spi.JsonException;
 
 public class TestIterImpl extends TestCase {
 
+	/**Test case that cover the switch case for escape code \b
+	We read only one character so j is only incremented by 1 and we assert that
+	*/
 	public void testEscapeCode_b() throws Exception{
 	    String escape = "\\b\"";
 	    JsonIterator iter = JsonIterator.parse(escape);
@@ -13,6 +16,9 @@ public class TestIterImpl extends TestCase {
 	    assertEquals(test, 1);
         } 
 
+	/**Test case that cover the switch case for escape code \n
+        We read only one character so j is only incremented by 1 and we assert that
+        */
 	public void testEscapeCode_n() throws Exception{
             String escape = "\\n\"";
             JsonIterator iter = JsonIterator.parse(escape);
@@ -21,6 +27,9 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 1);
         }
 
+	/**Test case that cover the switch case for escape code \f
+        We read only one character so j is only incremented by 1 and we assert that
+        */
 	public void testEscapeCode_f() throws Exception{
             String escape = "\\f\"";
             JsonIterator iter = JsonIterator.parse(escape);
@@ -29,6 +38,9 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 1);
         }
 
+	/**Test case that cover the switch case for escape code \r
+        We read only one character so j is only incremented by 1 and we assert that
+        */
 	public void testEscapeCode_r() throws Exception{
             String escape = "\\r\"";
             JsonIterator iter = JsonIterator.parse(escape);
@@ -37,6 +49,10 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 1);
         }
 
+	/**Test case that cover the switch case for escape code \u with a high surrogate
+	followed by a low surrogate
+        We read only two characters so j is only incremented by 2 and we assert that
+        */
 	public void testLowSurrogate() throws Exception{
             String escape = "\\ud832\\udc84\"";
             JsonIterator iter = JsonIterator.parse(escape);
@@ -45,6 +61,10 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 2);
         }
 
+	/**Test case that cover the switch case for escape code \u with a high surrogate
+        followed by a random unicode (which is neither low or high surrogate)
+        This should result in a JsonException and we assert that the message is the good one
+        */
 	public void testErrorSurrogate() throws Exception{
 	    try{	
                 String escape = "\\ud832\\u30a6\"";
@@ -57,6 +77,11 @@ public class TestIterImpl extends TestCase {
 	    }
         }
 
+	/**Test case that cover the case of a valid unicode where we split surrogate 
+	and the reusableChars array is supposed to be full j==length
+        We read only two characters (one unicode and ") so j is only incremented by 2 
+	and we assert that
+        */
 	public void testSplitSurrogate_reusablefull() throws Exception{
 	    byte b1 = (byte) -16;
 	    byte b2 = (byte) -18;
@@ -76,6 +101,11 @@ public class TestIterImpl extends TestCase {
             assertEquals(test, 34);
         }
 
+	/**Test case that cover the case of a valid unicode where we split surrogate
+        and the reusableChars array is supposed to have only one place remaining j==length-1
+        We read only two characters (one unicode and ") so j is only incremented by 2
+        and we assert that
+        */
 	public void testSplitSurrogate_reusableOneplaceleft() throws Exception{
             byte b1 = (byte) -16;
             byte b2 = (byte) -18;

--- a/src/test/java/com/jsoniter/TestIterImpl.java
+++ b/src/test/java/com/jsoniter/TestIterImpl.java
@@ -1,6 +1,7 @@
 package com.jsoniter;
 
 import junit.framework.TestCase;
+import com.jsoniter.spi.JsonException;
 
 public class TestIterImpl extends TestCase {
 
@@ -35,4 +36,25 @@ public class TestIterImpl extends TestCase {
             int test = IterImpl.readStringSlowPath(iter, j);
             assertEquals(test, 1);
         }
+
+	public void testLowSurrogate() throws Exception{
+            String escape = "\\ud832\\udc84\"";
+            JsonIterator iter = JsonIterator.parse(escape);
+            int j = 0;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 2);
+        }
+
+	public void testErrorSurrogate() throws Exception{
+	    try{	
+                String escape = "\\ud832\\u30a6\"";
+                JsonIterator iter = JsonIterator.parse(escape);
+		int j = 0;
+                int test = IterImpl.readStringSlowPath(iter, j);
+		fail();
+	    } catch (JsonException e){
+                assertEquals(e.getMessage(), "invalid surrogate");
+	    }
+        }
 }
+

--- a/src/test/java/com/jsoniter/TestIterImpl.java
+++ b/src/test/java/com/jsoniter/TestIterImpl.java
@@ -1,0 +1,38 @@
+package com.jsoniter;
+
+import junit.framework.TestCase;
+
+public class TestIterImpl extends TestCase {
+
+	public void testEscapeCode_b() throws Exception{
+	    String escape = "\\b\"";
+	    JsonIterator iter = JsonIterator.parse(escape);
+	    int j = 0;
+	    int test = IterImpl.readStringSlowPath(iter, j);
+	    assertEquals(test, 1);
+        } 
+
+	public void testEscapeCode_n() throws Exception{
+            String escape = "\\n\"";
+            JsonIterator iter = JsonIterator.parse(escape);
+            int j = 0;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 1);
+        }
+
+	public void testEscapeCode_f() throws Exception{
+            String escape = "\\f\"";
+            JsonIterator iter = JsonIterator.parse(escape);
+            int j = 0;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 1);
+        }
+
+	public void testEscapeCode_r() throws Exception{
+            String escape = "\\r\"";
+            JsonIterator iter = JsonIterator.parse(escape);
+            int j = 0;
+            int test = IterImpl.readStringSlowPath(iter, j);
+            assertEquals(test, 1);
+        }
+}

--- a/src/test/java/com/jsoniter/suite/AllTestCases.java
+++ b/src/test/java/com/jsoniter/suite/AllTestCases.java
@@ -56,6 +56,7 @@ import org.junit.runners.Suite;
         TestCollection.class,
         TestList.class,
         TestAnnotationJsonObject.class,
-        TestLong.class})
+        TestLong.class,
+	TestIterImpl.class})
 public abstract class AllTestCases {
 }


### PR DESCRIPTION
Add 8 test cases that improve coverage of the function readStringSlowPath in IterImpl.java to almost 100% (only two exceptions not coverred)
This should resolve #61 