### PR TITLE
Added a test for IterImplNumber::readInt (and IterImpl::readInt)

### DIFF
--- a/src/test/java/com/jsoniter/TestIterImplNumber.java
+++ b/src/test/java/com/jsoniter/TestIterImplNumber.java
@@ -1,0 +1,21 @@
+package com.jsoniter;
+
+import junit.framework.TestCase;
+import com.jsoniter.spi.*;
+
+/**
+    Testing IterImplNumber::readInt and by extension also IterImpl::readInt,
+    since the first's functionality is based on the latter's.
+*/
+public class TestIterImplNumber extends TestCase{
+    public void test_readInt() throws Exception{
+        // Should yield an exception, since no int can be parsed from this iterator.
+        JsonIterator iter = JsonIterator.parse("h");
+        try{
+            IterImplNumber.readInt(iter);
+            fail();
+        }catch(JsonException e){
+            assertEquals(e.getMessage().contains("expect 0~9"), true);
+        }
+    }
+}

--- a/src/test/java/com/jsoniter/suite/AllTestCases.java
+++ b/src/test/java/com/jsoniter/suite/AllTestCases.java
@@ -61,7 +61,8 @@ import org.junit.runners.Suite;
 	TestIterImpl.class,
         MoreIterImplForStreamingTest.class,
         TestIterImplSkip.class,
-        com.jsoniter.extra.TestGsonCompatibilityMode.class})
+        com.jsoniter.extra.TestGsonCompatibilityMode.class,
+        TestIterImplNumber.class})
 
 public abstract class AllTestCases {
 }


### PR DESCRIPTION
Added a new test file (TestIterImplNumber.java) which increases the coverage of CCN 12 function IterImpl::readInt by one branch by calling it through IterImplNumber::readInt. IterImplNumber::readInt employs IterImpl::readInt for its functionality.

This should resolve #129.